### PR TITLE
Find definition.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as vscode from 'vscode';
 
 export const LEAN_MODE : vscode.DocumentFilter = {

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -1,4 +1,3 @@
-'use strict';
 import * as vscode from 'vscode'
 import {DefinitionProvider, TextDocument, Position, Definition, Location, Uri} from 'vscode'
 import {Server} from './server'

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -1,0 +1,24 @@
+'use strict';
+import * as vscode from 'vscode'
+import {DefinitionProvider, TextDocument, Position, Definition, Location, Uri} from 'vscode'
+import {Server} from './server'
+
+export class LeanDefinitionProvider implements DefinitionProvider {
+    server : Server;
+
+    public constructor(server : Server) {
+        this.server = server;
+    }
+
+    public provideDefinition(document: TextDocument, position: Position,  CancellationToken): Thenable<Definition> {
+        return this.server.info(document.fileName, position.line + 1, position.character).then((response) => {
+            if (response.record && response.record.source) {
+                let src = response.record.source;
+                let uri = src.file ? Uri.file(src.file) : document.uri;
+                return new Location(uri, new Position(src.line - 1, src.column));
+            } else {
+                return null;
+            }
+        });
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,3 @@
-'use strict';
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import { Server } from './server';
 import { LeanHoverProvider } from './hover';
 import { LeanCompletionItemProvider } from './completion';
+import { LeanDefinitionProvider } from './definition'
 
 const LEAN_MODE : vscode.DocumentFilter = {
     language: "lean",
@@ -79,6 +80,11 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.languages.registerCompletionItemProvider(
             LEAN_MODE, new LeanCompletionItemProvider(server), '.'));
+
+    // Register support for definitions
+    context.subscriptions.push(
+        vscode.languages.registerDefinitionProvider(
+            LEAN_MODE, new LeanDefinitionProvider(server)));
 
     // Send a sync message when the editor changes.
     vscode.workspace.onDidChangeTextDocument((event) => {

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as vscode from 'vscode';
 import {Server} from './server';
 import {HoverProvider, Hover, TextDocument, Position, CancellationToken} from 'vscode';

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -12,16 +12,14 @@ export class LeanHoverProvider implements HoverProvider {
     }
 
     public provideHover(document : TextDocument, position : Position, CancellationToken) : Thenable<Hover> {
-        return this.server.sync(document.fileName, document.getText()).then((sync_response) => {
-            return this.server.info(document.fileName, position.line + 1, position.character).then((response) => {
-                if (response.record) {
-                    let msg = response.record['full-id'] + ' : ' + response.record['type'];
-                    let marked = { language: 'lean', value: msg };
-                    return new Hover(marked, new vscode.Range(position.line, position.character, position.line, position.character));
-                } else {
-                    return null;
-                }
-            });
+        return this.server.info(document.fileName, position.line + 1, position.character).then((response) => {
+            if (response.record) {
+                let msg = response.record['full-id'] + ' : ' + response.record['type'];
+                let marked = { language: 'lean', value: msg };
+                return new Hover(marked, new vscode.Range(position.line, position.character, position.line, position.character));
+            } else {
+                return null;
+            }
         });
     }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as child from 'child_process';
 import * as carrier from 'carrier';
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,11 +43,13 @@ class SequenceMap {
     [index : number] : (a : any) => any;
 }
 
+type Message = { file_name : string, pos_line : number, pos_col : number, severity : string, caption : string, text : string };
+
 // A class for interacting with the Lean server protoccol.
 class Server {
     process : child.ChildProcess;
     sequence_number : number;
-    messages : Array<any>;
+    messages : Array<Message>;
     senders : SequenceMap;
     on_message_callback : (a : any) => any;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
             "es6"
         ],
         "sourceMap": true,
+        "alwaysStrict": true,
         "rootDir": "."
     },
     "exclude": [


### PR DESCRIPTION
Just as with info support, this only works if put the cursor exactly on the first character of the identifier you want to look up.